### PR TITLE
Allow routington to work with browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,5 @@
-module.exports = require('./lib/routington')
+module.exports = require('./lib/routington');
 
-;[
-  'define',
-  'match',
-  'parse'
-].forEach(function (x) {
-  require('./lib/' + x)
-})
+require('./lib/define');
+require('./lib/match');
+require('./lib/parse');


### PR DESCRIPTION
[Browserify](http://browserify.org/) walks the AST of a project and its dependencies to pack a single JS file fit to run in a browser. It, unfortunately, doesn't work too well when the require directives are anything but declarative. This change makes the imports in index.js explicit.
